### PR TITLE
In-memory substitute

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,6 +2,7 @@ module.exports = {
   'env': {
     'commonjs': true,
     'es6': true,
+    'mocha': true,
     'node': true
   },
   'extends': 'eslint:recommended',

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ yarn add @articulate/hermes
 
 ## Setup
 
-Follow the [setup instructions](https://github.com/message-db/message-db) for Message DB to initialize the message store, or use [this Docker image](https://hub.docker.com/r/ethangarofolo/message-db) for local dev.  Then provide connection options as below:
+Follow the [setup instructions](https://github.com/message-db/message-db) for Message DB to initialize the message store, or use [this Docker image](https://hub.docker.com/r/articulate/message-db) for local dev.  Then provide connection options as below:
 
 ```js
 // server/lib/hermes.js
@@ -34,6 +34,8 @@ module.exports = require('@articulate/hermes')({
 You'll need at least a `connectionString`, but see the following for the full list of available options:
 - https://node-postgres.com/api/client
 - https://node-postgres.com/api/pool
+
+**Note:** You may alternatively specify the connection options using [standard Postgres environment variables](https://www.postgresql.org/docs/current/libpq-envars.html).
 
 ## Documentation
 
@@ -64,9 +66,29 @@ DEBUG_DEPTH=null
 DEBUG_HIDE_DATE=true
 ```
 
+## Mocking
+
+To help you test your [autonomous services](https://articulate.github.io/hermes/#/core-concepts?id=service), Hermes ships with an in-memory substitute that passes [the same test suite](https://github.com/articulate/hermes/tree/master/test) as the default Message DB implementation.  Enable it with the `{ mock: true }` flag.  When enabled, Hermes will ignore any connection options specified, and will not connect to Postgres.
+
+In addition, you may clear the in-memory store after each test using `hermes.store.clear()`.
+
+```js
+const hermes = require('@articulate/hermes')({
+  mock: process.env.NODE_ENV === 'test'
+})
+
+afterEach(() => {
+  hermes.store.clear()
+})
+```
+
+**Read more** about testing with Hermes in the section on [entity caching](https://articulate.github.io/hermes/#/api?id=caching).
+
+> **Not for production use.**  The in-memory substitute implementation is only intended for testing.
+
 ## Tests
 
-The tests run in [Travis CI](https://travis-ci.org/github/articulate/hermes), but you can run the tests locally with `docker-compose` like so:
+The [Hermes tests](https://github.com/articulate/hermes/tree/master/test) run in [Travis CI](https://travis-ci.org/github/articulate/hermes), but you can run the tests locally with `docker-compose` like so:
 
 ```
 docker-compose build

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,7 @@ yarn add @articulate/hermes
 
 ## Setup
 
-Follow the [setup instructions](https://github.com/message-db/message-db) for Message DB to initialize the message store, or use [this Docker image](https://hub.docker.com/r/ethangarofolo/message-db) for local dev.  Then provide connection options as below:
+Follow the [setup instructions](https://github.com/message-db/message-db) for Message DB to initialize the message store, or use [this Docker image](https://hub.docker.com/r/articulate/message-db) for local dev.  Then provide connection options as below:
 
 ```js
 // server/lib/hermes.js
@@ -39,6 +39,8 @@ module.exports = require('@articulate/hermes')({
 You'll need at least a `connectionString`, but see the following for the full list of available options:
 - https://node-postgres.com/api/client
 - https://node-postgres.com/api/pool
+
+**Note:** You may alternatively specify the connection options using [standard Postgres environment variables](https://www.postgresql.org/docs/current/libpq-envars.html).
 
 ## Documentation
 
@@ -69,9 +71,29 @@ DEBUG_DEPTH=null
 DEBUG_HIDE_DATE=true
 ```
 
+## Mocking
+
+To help you test your [autonomous services](/core-concepts?id=service), Hermes ships with an in-memory substitute that passes [the same test suite](https://github.com/articulate/hermes/tree/master/test) as the default Message DB implementation.  Enable it with the `{ mock: true }` flag.  When enabled, Hermes will ignore any connection options specified, and will not connect to Postgres.
+
+In addition, you may clear the in-memory store after each test using `hermes.store.clear()`.
+
+```js
+const hermes = require('@articulate/hermes')({
+  mock: process.env.NODE_ENV === 'test'
+})
+
+afterEach(() => {
+  hermes.store.clear()
+})
+```
+
+**Read more** about testing with Hermes in the section on [entity caching](/api?id=caching).
+
+!> **Not for production use.**  The in-memory substitute implementation is only intended for testing.
+
 ## Tests
 
-The tests run in [Travis CI](https://travis-ci.org/github/articulate/hermes), but you can run the tests locally with `docker-compose` like so:
+The [Hermes tests](https://github.com/articulate/hermes/tree/master/test) run in [Travis CI](https://travis-ci.org/github/articulate/hermes), but you can run the tests locally with `docker-compose` like so:
 
 ```
 docker-compose build

--- a/docs/api.md
+++ b/docs/api.md
@@ -373,3 +373,21 @@ writeMessage({
 ```
 
 If the current stream version doesn't match, then `writeMessage` will reject with a [`VersionConflictError`](/extras?id=versionconflicterror) that you can [catch and retry](/api?id=error-handling).
+
+### Initial Message
+
+Sometimes you'll want to ensure that a particular message is the first in its stream, either to start off a new business process, or to implement the [reservation pattern](/idempotence-patterns).  To do so, set `{ expectedVersion: -1 }`.
+
+?> **Don't forget:** the [version of an empty stream](/core-concepts?id=stream) is `-1`.
+
+This is a common enough pattern than Hermes includes a `writeMessage.initial` function to simplify it for you:
+
+```js
+const { writeMessage } = require('../lib/hermes')
+
+writeMessage.initial({
+  streamVersion: `userId-${email}`,
+  type: 'Linked',
+  data: { userId, email }
+})
+```

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "scripts": {
     "docs": "docsify serve -p 4000 ./docs",
-    "lint": "eslint src",
+    "lint": "eslint src test",
     "test": "mocha"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "highland": "^2.13.5",
     "mnemonist": "^0.32.0",
     "pg": "^7.18.2",
-    "tinyfunk": "^1.7.2",
+    "tinyfunk": "^1.7.3",
     "uuid": "^7.0.2"
   },
   "devDependencies": {

--- a/src/api/Consumer.js
+++ b/src/api/Consumer.js
@@ -28,6 +28,7 @@ const Consumer = db => opts => {
   const streamName = `${category}+position-${name}${suffix}`
 
   let count
+  let nextTick
   let pending
   let position
   let up = false
@@ -100,6 +101,7 @@ const Consumer = db => opts => {
   const stop = err => {
     if (up) {
       debug(`stopping${err ? ' on error' : ''}`)
+      clearTimeout(nextTick)
       up = false
     }
 
@@ -115,11 +117,12 @@ const Consumer = db => opts => {
   }
 
   const tick = () => {
-    setTimeout(poll, tickInterval)
+    nextTick = setTimeout(poll, tickInterval)
   }
 
   const updatePosition = msg => {
     position = msg.globalPosition + 1
+    debug('new position: %o', position)
     count++
 
     if (count >= positionUpdateInterval) {

--- a/src/api/Entity.js
+++ b/src/api/Entity.js
@@ -59,6 +59,13 @@ const Entity = db => opts => {
 
   const cache = cacheEnabled && new LRUCache(cacheLimit)
 
+  const clear = () => {
+    if (cache) {
+      cache.clear()
+      debug('cache cleared')
+    }
+  }
+
   const fetch = async id => {
     debug('fetching: %o', id)
     let record
@@ -138,7 +145,7 @@ const Entity = db => opts => {
       data: cleanSnapshot(record)
     })
 
-  return { fetch }
+  return { clear, fetch }
 }
 
 module.exports = Entity

--- a/src/db/memory/getCategoryMessages.js
+++ b/src/db/memory/getCategoryMessages.js
@@ -1,0 +1,17 @@
+const _ = require('highland')
+
+const debug = require('../../lib/debug').extend('db')
+
+// getCategoryMessages :: Object -> Stream Message
+const getCategoryMessages = store => opts => {
+  debug('getting category messages: %o', opts)
+
+  const { category, position = 1 } = opts
+
+  const byPosition = msg =>
+    msg.globalPosition >= position
+
+  return _(store.streams.get(category) || []).filter(byPosition)
+}
+
+module.exports = getCategoryMessages

--- a/src/db/memory/getLastStreamMessage.js
+++ b/src/db/memory/getLastStreamMessage.js
@@ -1,0 +1,17 @@
+const { last } = require('tinyfunk')
+
+const debug = require('../../lib/debug').extend('db')
+
+// getLastStreamMessage :: String -> Promise Message
+const getLastStreamMessage = store => async streamName => {
+  debug('getting last message: %o', { streamName })
+
+  const message = last(store.streams.get(streamName) || [])
+
+  if (message) debug('last message found: %o', message)
+  else debug('stream empty: %o', { streamName })
+
+  return message
+}
+
+module.exports = getLastStreamMessage

--- a/src/db/memory/getStreamMessages.js
+++ b/src/db/memory/getStreamMessages.js
@@ -1,0 +1,17 @@
+const _ = require('highland')
+
+const debug = require('../../lib/debug').extend('db')
+
+// getCategoryMessages :: Object -> Stream Message
+const getCategoryMessages = store => opts => {
+  debug('getting stream messages: %o', opts)
+
+  const { position = 0, streamName } = opts
+
+  const byPosition = msg =>
+    msg.position >= position
+
+  return _(store.streams.get(streamName) || []).filter(byPosition)
+}
+
+module.exports = getCategoryMessages

--- a/src/db/memory/index.js
+++ b/src/db/memory/index.js
@@ -1,5 +1,7 @@
 const { mapObj, merge, pipe, thrush } = require('tinyfunk')
 
+const debug = require('../../lib/debug').extend('db')
+
 const db = {
   getCategoryMessages: require('./getCategoryMessages'),
   getLastStreamMessage: require('./getLastStreamMessage'),
@@ -19,6 +21,7 @@ const dbFactory = () => {
     store.lastMessage = null
     store.messages.length = 0
     store.streams.clear()
+    debug('store cleared')
   }
 
   return pipe(

--- a/src/db/memory/index.js
+++ b/src/db/memory/index.js
@@ -1,0 +1,30 @@
+const { mapObj, merge, pipe, thrush } = require('tinyfunk')
+
+const db = {
+  getCategoryMessages: require('./getCategoryMessages'),
+  getLastStreamMessage: require('./getLastStreamMessage'),
+  getStreamMessages: require('./getStreamMessages'),
+  streamVersion: require('./streamVersion'),
+  writeMessage: require('./writeMessage')
+}
+
+const dbFactory = () => {
+  const store = {
+    lastMessage: null,
+    messages: [],
+    streams: new Map()
+  }
+
+  store.clear = () => {
+    store.lastMessage = null
+    store.messages.length = 0
+    store.streams.clear()
+  }
+
+  return pipe(
+    mapObj(thrush(store)),
+    merge({ store })
+  )(db)
+}
+
+module.exports = dbFactory

--- a/src/db/memory/streamVersion.js
+++ b/src/db/memory/streamVersion.js
@@ -1,0 +1,11 @@
+const debug = require('../../lib/debug').extend('db')
+
+// streamVersion :: String -> Promise Number
+const streamVersion = store => async streamName => {
+  debug('loading stream version: %o', { streamName })
+  const version = (store.streams.get(streamName) || []).length - 1
+  debug('stream version loaded: %o', { streamName, version })
+  return version
+}
+
+module.exports = streamVersion

--- a/src/db/memory/writeMessage.js
+++ b/src/db/memory/writeMessage.js
@@ -1,59 +1,66 @@
-const { merge } = require('tinyfunk')
+const { assoc, compose, merge } = require('tinyfunk')
 const uuid = require('uuid')
 
 const debug = require('../../lib/debug').extend('db')
 const VersionConflictError = require('../../lib/VersionConflictError')
 
 // writeMessage :: Message -> Promise Message
-const writeMessage = store => async message => {
-  if (!message.type)
-    return Promise.reject(new Error('Messages must have a type'))
+const writeMessage = store => {
+  const write = async message => {
+    if (!message.type)
+      return Promise.reject(new Error('Messages must have a type'))
 
-  const { expectedVersion, streamName } = message
-  const id = uuid.v4()
-  const result = { id, ...message }
-  debug('writing message: %o', result)
+    const { expectedVersion, streamName } = message
+    const id = uuid.v4()
+    const result = { id, ...message }
+    debug('writing message: %o', result)
 
-  const categoryName = streamName.split('-')[0]
-  let category = store.streams.get(categoryName)
-  let stream = store.streams.get(streamName)
+    const categoryName = streamName.split('-')[0]
+    let category = store.streams.get(categoryName)
+    let stream = store.streams.get(streamName)
 
-  if (!category) {
-    category = []
-    store.streams.set(categoryName, category)
-  }
-
-  if (!stream) {
-    stream = []
-    store.streams.set(streamName, stream)
-  }
-
-  if (typeof expectedVersion === 'number') {
-    const actualVersion = stream.length - 1
-
-    if (expectedVersion !== actualVersion) {
-      const err = new VersionConflictError({
-        actualVersion,
-        expectedVersion,
-        streamName
-      })
-
-      return Promise.reject(err)
+    if (!category) {
+      category = []
+      store.streams.set(categoryName, category)
     }
+
+    if (!stream) {
+      stream = []
+      store.streams.set(streamName, stream)
+    }
+
+    if (typeof expectedVersion === 'number') {
+      const actualVersion = stream.length - 1
+
+      if (expectedVersion !== actualVersion) {
+        const err = new VersionConflictError({
+          actualVersion,
+          expectedVersion,
+          streamName
+        })
+
+        return Promise.reject(err)
+      }
+    }
+
+    const record = merge(result, {
+      globalPosition: store.messages.length + 1,
+      position: stream.length,
+      time: new Date().toJSON()
+    })
+
+    category.push(record)
+    stream.push(record)
+    store.messages.push(record)
+    store.lastMessage = record
+
+    return result
   }
 
-  const record = merge(result, {
-    globalPosition: store.messages.length + 1,
-    position: stream.length,
-    time: new Date().toJSON()
-  })
+  write.initial =
+    compose(write, assoc('expectedVersion', -1))
 
-  category.push(record)
-  stream.push(record)
-  store.messages.push(record)
-  store.lastMessage = record
-
-  return result
+  return write
 }
 
 module.exports = writeMessage

--- a/src/db/memory/writeMessage.js
+++ b/src/db/memory/writeMessage.js
@@ -1,0 +1,59 @@
+const { merge } = require('tinyfunk')
+const uuid = require('uuid')
+
+const debug = require('../../lib/debug').extend('db')
+const VersionConflictError = require('../../lib/VersionConflictError')
+
+// writeMessage :: Message -> Promise Message
+const writeMessage = store => async message => {
+  if (!message.type)
+    return Promise.reject(new Error('Messages must have a type'))
+
+  const { expectedVersion, streamName } = message
+  const id = uuid.v4()
+  const result = { id, ...message }
+  debug('writing message: %o', result)
+
+  const categoryName = streamName.split('-')[0]
+  let category = store.streams.get(categoryName)
+  let stream = store.streams.get(streamName)
+
+  if (!category) {
+    category = []
+    store.streams.set(categoryName, category)
+  }
+
+  if (!stream) {
+    stream = []
+    store.streams.set(streamName, stream)
+  }
+
+  if (typeof expectedVersion === 'number') {
+    const actualVersion = stream.length - 1
+
+    if (expectedVersion !== actualVersion) {
+      const err = new VersionConflictError({
+        actualVersion,
+        expectedVersion,
+        streamName
+      })
+
+      return Promise.reject(err)
+    }
+  }
+
+  const record = merge(result, {
+    globalPosition: store.messages.length + 1,
+    position: stream.length,
+    time: new Date().toJSON()
+  })
+
+  category.push(record)
+  stream.push(record)
+  store.messages.push(record)
+  store.lastMessage = record
+
+  return result
+}
+
+module.exports = writeMessage

--- a/src/db/postgres/getCategoryMessages.js
+++ b/src/db/postgres/getCategoryMessages.js
@@ -1,8 +1,8 @@
 const _ = require('highland')
 const { tap } = require('tinyfunk')
 
-const debug = require('../lib/debug').extend('db')
-const parseMessage = require('../lib/parseMessage')
+const debug = require('../../lib/debug').extend('db')
+const parseMessage = require('../../lib/parseMessage')
 
 const sql = 'SELECT * FROM message_store.get_category_messages($1, $2, $3, $4, $5, $6, $7)'
 

--- a/src/db/postgres/getLastStreamMessage.js
+++ b/src/db/postgres/getLastStreamMessage.js
@@ -1,7 +1,7 @@
 const { head } = require('tinyfunk')
 
-const debug = require('../lib/debug').extend('db')
-const parseMessage = require('../lib/parseMessage')
+const debug = require('../../lib/debug').extend('db')
+const parseMessage = require('../../lib/parseMessage')
 
 const sql = 'SELECT * FROM message_store.get_last_stream_message($1)'
 

--- a/src/db/postgres/getStreamMessages.js
+++ b/src/db/postgres/getStreamMessages.js
@@ -1,8 +1,8 @@
 const _ = require('highland')
 const { tap } = require('tinyfunk')
 
-const debug = require('../lib/debug').extend('db')
-const parseMessage = require('../lib/parseMessage')
+const debug = require('../../lib/debug').extend('db')
+const parseMessage = require('../../lib/parseMessage')
 
 const sql = 'SELECT * FROM message_store.get_stream_messages($1, $2, $3, $4)'
 

--- a/src/db/postgres/index.js
+++ b/src/db/postgres/index.js
@@ -1,8 +1,8 @@
 const { mapObj, merge, pipe, thrush } = require('tinyfunk')
 const { Pool } = require('pg')
 
-const debug = require('../lib/debug').extend('db')
-const once = require('../lib/once')
+const debug = require('../../lib/debug').extend('db')
+const once = require('../../lib/once')
 
 const db = {
   getCategoryMessages: require('./getCategoryMessages'),

--- a/src/db/postgres/streamVersion.js
+++ b/src/db/postgres/streamVersion.js
@@ -1,6 +1,6 @@
 const { compose, defaultTo, path } = require('tinyfunk')
 
-const debug = require('../lib/debug').extend('db')
+const debug = require('../../lib/debug').extend('db')
 
 const sql = 'SELECT * FROM message_store.stream_version($1)'
 

--- a/src/db/postgres/writeMessage.js
+++ b/src/db/postgres/writeMessage.js
@@ -1,3 +1,4 @@
+const { assoc, compose } = require('tinyfunk')
 const uuid = require('uuid')
 
 const debug = require('../../lib/debug').extend('db')
@@ -6,28 +7,35 @@ const handleVersionConflict = require('../../lib/handleVersionConflict')
 const writeSql = 'SELECT message_store.write_message($1, $2, $3, $4, $5, $6)'
 
 // writeMessage :: Message -> Promise Message
-const writeMessage = ({ query }) => async message => {
-  if (!message.type)
-    return Promise.reject(new Error('Messages must have a type'))
+const writeMessage = ({ query }) => {
+  const write = async message => {
+    if (!message.type)
+      return Promise.reject(new Error('Messages must have a type'))
 
-  const { data, expectedVersion, metadata, streamName, type } = message
-  const id = uuid.v4()
-  const result = { id, ...message }
-  debug('writing message: %o', result)
+    const { data, expectedVersion, metadata, streamName, type } = message
+    const id = uuid.v4()
+    const result = { id, ...message }
+    debug('writing message: %o', result)
 
-  const vals = [
-    id,
-    streamName,
-    type,
-    data,
-    metadata,
-    expectedVersion
-  ]
+    const vals = [
+      id,
+      streamName,
+      type,
+      data,
+      metadata,
+      expectedVersion
+    ]
 
-  await query(writeSql, vals)
-    .catch(handleVersionConflict({ expectedVersion, streamName }))
+    await query(writeSql, vals)
+      .catch(handleVersionConflict({ expectedVersion, streamName }))
 
-  return result
+    return result
+  }
+
+  write.initial =
+    compose(write, assoc('expectedVersion', -1))
+
+  return write
 }
 
 module.exports = writeMessage

--- a/src/db/postgres/writeMessage.js
+++ b/src/db/postgres/writeMessage.js
@@ -1,7 +1,7 @@
 const uuid = require('uuid')
 
-const debug = require('../lib/debug').extend('db')
-const handleVersionConflict = require('../lib/handleVersionConflict')
+const debug = require('../../lib/debug').extend('db')
+const handleVersionConflict = require('../../lib/handleVersionConflict')
 
 const writeSql = 'SELECT message_store.write_message($1, $2, $3, $4, $5, $6)'
 

--- a/src/index.js
+++ b/src/index.js
@@ -7,8 +7,9 @@ const extras = {
 }
 
 // hermes :: Object -> Object
-const hermes = opts => {
-  const db = require('./db')(opts)
+const hermes = ({ mock=false, ...opts }) => {
+  const driver = mock ? 'memory' : 'postgres'
+  const db = require(`./db/${driver}`)(opts)
   return Object.assign({}, mapObj(thrush(db), api), db, extras)
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ const { mapObj, thrush } = require('tinyfunk')
 const api = require('./api')
 
 const extras = {
+  follow: require('./lib/follow'),
   VersionConflictError: require('./lib/VersionConflictError')
 }
 

--- a/src/lib/follow.js
+++ b/src/lib/follow.js
@@ -1,0 +1,15 @@
+const { curry, merge, path } = require('tinyfunk')
+
+const follow = (prev, next) => {
+  const metadata = Object.assign({}, next.metadata)
+
+  metadata.causationMessageGlobalPosition = prev.globalPosition
+  metadata.causationMessagePosition = prev.position
+  metadata.causationMessageStreamName = prev.streamName
+  metadata.correlationStreamName = path(['metadata', 'correlationStreamName'], prev)
+  metadata.replyStreamName = path(['metadata', 'replyStreamName'], prev)
+
+  return merge(next, { metadata })
+}
+
+module.exports = curry(follow)

--- a/test/Consumer.js
+++ b/test/Consumer.js
@@ -2,12 +2,14 @@ const { expect } = require('chai')
 const spy = require('@articulate/spy')
 const wait = require('util').promisify(setTimeout)
 
-const { Consumer, writeMessage } = require('./lib/hermes')
+const { memory, postgres } = require('./lib/hermes')
 const Signup = require('./lib/Signup')
 
-describe('Consumer', () => {
+const test = hermes => () => {
+  const { Consumer, writeMessage } = hermes
+
   describe('when things go well', () => {
-    let init, testSignup
+    let init, testSignup, UserSignup
 
     beforeEach(() => {
       init = spy()
@@ -106,4 +108,9 @@ describe('Consumer', () => {
       expect(onError.calls.length).to.equal(1) // must have stopped
     })
   })
+}
+
+describe('Consumer', () => {
+  describe('in memory', test(memory))
+  describe('in postgres', test(postgres))
 })

--- a/test/Entity.js
+++ b/test/Entity.js
@@ -3,10 +3,11 @@ const { expect } = require('chai')
 const spy = require('@articulate/spy')
 const uuid = require('uuid')
 
-const { Entity, streamVersion, writeMessage } = require('./lib/hermes')
+const { memory, postgres } = require('./lib/hermes')
 const Viewed = require('./lib/Viewed')
 
-describe('Entity', () => {
+const test = hermes => () => {
+  const { Entity, streamVersion, writeMessage } = hermes
   let Viewing
 
   describe('when category is missing', () => {
@@ -37,6 +38,7 @@ describe('Entity', () => {
     })
 
     it('safely defaults to an empty object of handlers', async () => {
+      /* eslint-disable-next-line no-unused-vars */
       const [ entity, version ] = await Viewing.fetch('anything')
       expect(entity).to.eql({ views: 0 })
     })
@@ -55,11 +57,13 @@ describe('Entity', () => {
     })
 
     it('resolves with the init', async () => {
+      /* eslint-disable-next-line no-unused-vars */
       const [ entity, version ] = await Viewing.fetch('anything')
       expect(entity).to.eql({ views: 0 })
     })
 
     it('also includes a version of -1', async () => {
+      /* eslint-disable-next-line no-unused-vars */
       const [ entity, version ] = await Viewing.fetch('anything')
       expect(version).to.equal(-1)
     })
@@ -87,11 +91,13 @@ describe('Entity', () => {
     })
 
     it('projects over the events to build the entity', async () => {
+      /* eslint-disable-next-line no-unused-vars */
       const [ entity, version ] = await Viewing.fetch(videoId)
       expect(entity).to.eql({ views: 3 })
     })
 
     it('also includes the version of the entity', async () => {
+      /* eslint-disable-next-line no-unused-vars */
       const [ entity, version ] = await Viewing.fetch(videoId)
       expect(version).to.equal(2)
     })
@@ -236,4 +242,9 @@ describe('Entity', () => {
       expect(version).to.equal(0)
     })
   })
+}
+
+describe('Entity', () => {
+  describe('in memory', test(memory))
+  describe('in postgres', test(postgres))
 })

--- a/test/_setup.js
+++ b/test/_setup.js
@@ -5,12 +5,15 @@ const hermes = require('./lib/hermes')
 const pg = require('./lib/pg')
 
 afterEach(() =>
-  pg.query('TRUNCATE message_store.messages RESTART IDENTITY')
+  Promise.all([
+    hermes.memory.store.clear(),
+    pg.query('TRUNCATE message_store.messages RESTART IDENTITY')
+  ])
 )
 
 after(() =>
   Promise.all([
-    hermes.cleanup(),
+    hermes.postgres.cleanup(),
     pg.cleanup()
   ])
 )

--- a/test/follow.js
+++ b/test/follow.js
@@ -1,0 +1,136 @@
+const { assocPath, pipe, prop } = require('tinyfunk')
+const { expect } = require('chai')
+const uuid = require('uuid')
+
+const { memory: { follow, store, writeMessage } } = require('./lib/hermes')
+
+describe.only('follow', () => {
+  const Rename = ({ name, userId }) =>
+    ({
+      streamName: `displayName:command-${userId}`,
+      type: 'Rename',
+      data: { name, time: new Date(), userId },
+    })
+
+  const Renamed = ({ name, time, userId }) =>
+    ({
+      streamName: `displayName-${userId}`,
+      type: 'Renamed',
+      data: { name, processedTime: new Date(), time, userId }
+    })
+
+  let cmd, evt
+
+  describe('tracks precedence', () => {
+    beforeEach(async () => {
+      await writeMessage(
+        Rename({
+          name: `Anonymous-${Math.floor(Math.random() * 10)}`,
+          userId: uuid.v4()
+        })
+      )
+
+      cmd = store.lastMessage
+
+      evt = pipe(
+        prop('data'),
+        Renamed,
+        follow(cmd)
+      )(cmd)
+    })
+
+    it('includes metadata.causationMessageGlobalPosition', () => {
+      expect(evt.metadata.causationMessageGlobalPosition).to.equal(cmd.globalPosition)
+    })
+
+    it('includes metadata.causationMessagePosition', () => {
+      expect(evt.metadata.causationMessagePosition).to.equal(cmd.position)
+    })
+
+    it('includes metadata.causationMessageStreamName', () => {
+      expect(evt.metadata.causationMessageStreamName).to.equal(cmd.streamName)
+    })
+
+    it('does not mind if correlationStreamName is absent', () => {
+      expect(evt.metadata.correlationStreamName).to.be.undefined
+    })
+
+    it('does not mind if replyStreamName is absent', () => {
+      expect(evt.metadata.replyStreamName).to.be.undefined
+    })
+  })
+
+  describe('when correlationStreamName provided', () => {
+    beforeEach(async () => {
+      cmd = Rename({
+        name: `Anonymous-${Math.floor(Math.random() * 10)}`,
+        userId: uuid.v4()
+      })
+
+      cmd.metadata = { correlationStreamName: `category-${uuid.v4()}` }
+
+      await writeMessage(cmd)
+
+      cmd = store.lastMessage
+
+      evt = pipe(
+        prop('data'),
+        Renamed,
+        follow(cmd)
+      )(cmd)
+    })
+
+    it('includes metadata.correlationStreamName', () => {
+      expect(evt.metadata.correlationStreamName).to.equal(cmd.metadata.correlationStreamName)
+    })
+  })
+
+  describe('when replyStreamName provided', () => {
+    beforeEach(async () => {
+      cmd = Rename({
+        name: `Anonymous-${Math.floor(Math.random() * 10)}`,
+        userId: uuid.v4()
+      })
+
+      cmd.metadata = { replyStreamName: `category-${uuid.v4()}` }
+
+      await writeMessage(cmd)
+
+      cmd = store.lastMessage
+
+      evt = pipe(
+        prop('data'),
+        Renamed,
+        follow(cmd)
+      )(cmd)
+    })
+
+    it('includes metadata.replyStreamName', () => {
+      expect(evt.metadata.replyStreamName).to.equal(cmd.metadata.replyStreamName)
+    })
+  })
+
+  describe('with extra metadata', () => {
+    beforeEach(async () => {
+      cmd = Rename({
+        name: `Anonymous-${Math.floor(Math.random() * 10)}`,
+        userId: uuid.v4()
+      })
+
+      await writeMessage(cmd)
+
+      cmd = store.lastMessage
+
+      evt = pipe(
+        prop('data'),
+        Renamed,
+        assocPath(['metadata', 'otherStuff'], 'untouched'),
+        follow(cmd)
+      )(cmd)
+    })
+
+    it('leaves it untouched', () => {
+      expect(evt.metadata.otherStuff).to.equal('untouched')
+    })
+  })
+})

--- a/test/follow.js
+++ b/test/follow.js
@@ -4,7 +4,7 @@ const uuid = require('uuid')
 
 const { memory: { follow, store, writeMessage } } = require('./lib/hermes')
 
-describe.only('follow', () => {
+describe('follow', () => {
   const Rename = ({ name, userId }) =>
     ({
       streamName: `displayName:command-${userId}`,

--- a/test/getCategoryMessages.js
+++ b/test/getCategoryMessages.js
@@ -2,10 +2,12 @@ const _ = require('highland')
 const { assoc } = require('tinyfunk')
 const { expect } = require('chai')
 
-const { getCategoryMessages, writeMessage } = require('./lib/hermes')
+const { memory, postgres } = require('./lib/hermes')
 const Signup = require('./lib/Signup')
 
-describe('getCategoryMessages', () => {
+const test = hermes => () => {
+  const { getCategoryMessages, writeMessage } = hermes
+
   it('returns a Highland stream', done => {
     const messages = getCategoryMessages({ category: 'empty' })
     expect(_.isStream(messages)).to.be.true
@@ -59,4 +61,9 @@ describe('getCategoryMessages', () => {
         })
     })
   })
+}
+
+describe('getCategoryMessages', () => {
+  describe('in memory', test(memory))
+  describe('in postgres', test(postgres))
 })

--- a/test/getLastStreamMessage.js
+++ b/test/getLastStreamMessage.js
@@ -1,10 +1,11 @@
 const { assoc } = require('tinyfunk')
 const { expect } = require('chai')
 
-const { getLastStreamMessage, writeMessage } = require('./lib/hermes')
+const { memory, postgres } = require('./lib/hermes')
 const Signup = require('./lib/Signup')
 
-describe('getLastStreamMessage', () => {
+const test = hermes => () => {
+  const { getLastStreamMessage, writeMessage } = hermes
   let command, message
 
   describe('when stream is empty', () => {
@@ -29,4 +30,9 @@ describe('getLastStreamMessage', () => {
       expect(message).to.deep.include(command)
     })
   })
+}
+
+describe('getLastStreamMessage', () => {
+  describe('in memory', test(memory))
+  describe('in postgres', test(postgres))
 })

--- a/test/getStreamMessages.js
+++ b/test/getStreamMessages.js
@@ -2,10 +2,12 @@ const _ = require('highland')
 const { assoc } = require('tinyfunk')
 const { expect } = require('chai')
 
-const { getStreamMessages, writeMessage } = require('./lib/hermes')
+const { memory, postgres } = require('./lib/hermes')
 const Signup = require('./lib/Signup')
 
-describe('getStreamMessages', () => {
+const test = hermes => () => {
+  const { getStreamMessages, writeMessage } = hermes
+
   it('returns a Highland stream', done => {
     const messages = getStreamMessages({ streamName: 'empty-stream' })
     expect(_.isStream(messages)).to.be.true
@@ -59,4 +61,9 @@ describe('getStreamMessages', () => {
         })
     })
   })
+}
+
+describe('getStreamMessages', () => {
+  describe('in memory', test(memory))
+  describe('in postgres', test(postgres))
 })

--- a/test/lib/hermes.js
+++ b/test/lib/hermes.js
@@ -1,3 +1,6 @@
-module.exports = require('../..')({
-  connectionString: process.env.MESSAGE_STORE_URI
-})
+const hermes = require('../..')
+
+const memory = hermes({ mock: true })
+const postgres = hermes({ connectionString: process.env.MESSAGE_STORE_URI })
+
+module.exports = { memory, postgres }

--- a/test/streamVersion.js
+++ b/test/streamVersion.js
@@ -1,9 +1,10 @@
 const { expect } = require('chai')
 
+const { memory, postgres } = require('./lib/hermes')
 const Signup = require('./lib/Signup')
-const { streamVersion, writeMessage } = require('./lib/hermes')
 
-describe('streamVersion', () => {
+const test = hermes => () => {
+  const { streamVersion, writeMessage } = hermes
   let command, version
 
   describe('when stream is empty', () => {
@@ -28,4 +29,9 @@ describe('streamVersion', () => {
       expect(version).to.equal(1)
     })
   })
+}
+
+describe('streamVersion', () => {
+  describe('in memory', test(memory))
+  describe('in postgres', test(postgres))
 })

--- a/test/writeMessage.js
+++ b/test/writeMessage.js
@@ -90,6 +90,16 @@ const test = hermes => () => {
       }
     })
   })
+
+  describe('writeMessage.initial', () => {
+    beforeEach(() =>
+      writeMessage.initial(valid).then(msg)
+    )
+
+    it('sets the expectedVersion to -1', () => {
+      expect(msg().expectedVersion).to.equal(-1)
+    })
+  })
 }
 
 describe('writeMessage', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1398,10 +1398,10 @@ through@2, through@^2.3.6:
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
 
-tinyfunk@^1.7.2:
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/tinyfunk/-/tinyfunk-1.7.2.tgz#8253c0f040037d3d277df22475ce2bd66276e18d"
-  integrity sha512-IFHz87e0FPBqX83C+4bqO58WBT8WD8r64GLv2763ouhXWOVK7UqNL6YioJ4lVeb84j1YUdWh5J2E3RFcnle8kQ==
+tinyfunk@^1.7.3:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/tinyfunk/-/tinyfunk-1.7.3.tgz#0e6b902dc915fb42a24fcca55c2cdc901ea2999c"
+  integrity sha512-Gf591+QxFhw9/0pRxoSsCzo7xtf+a+/A4enVubkRV+AysranHvsyGjXaCYt58Nd7VCCyZN5p7UZMfSDU3J/rPw==
 
 tmp@^0.0.33:
   version "0.0.33"


### PR DESCRIPTION
![mock yeah](https://i.imgur.com/jgZkinq.gif)

To simplify testing, this adds an in-memory substitute enabled with `{ mock: true }`.  More details in the new docs.  

Also added these two helpers after attending the Eventide workshop:

- `follow`
- `writeMessage.initial`

## to review:
- [ ] Wait for the green
- [ ] Fire up `yarn docs` to read about the new stuff